### PR TITLE
add values parameter in newContext

### DIFF
--- a/src/mustache.nim
+++ b/src/mustache.nim
@@ -19,6 +19,7 @@ export parse
 export `$`
 export `[]`
 export `[]=`
+export toValues
 
 when isMainModule:
   var p = initOptParser()

--- a/src/mustachepkg/values.nim
+++ b/src/mustachepkg/values.nim
@@ -49,7 +49,7 @@ proc loadPartial*(loader: Loader, filename: string): (bool, string) =
 
   return (false, "")
 
-proc newContext*(searchDirs = @["./"], partials = initTable[string, string]()): Context =
+proc newContext*(searchDirs = @["./"], partials = initTable[string, string](), values = initTable[string,Value]()): Context =
   var loaders: seq[Loader]
 
   if searchDirs.len != 0:
@@ -58,7 +58,7 @@ proc newContext*(searchDirs = @["./"], partials = initTable[string, string]()): 
   if partials.len != 0:
     loaders.add(Loader(kind: lkTable, table: partials))
 
-  Context(values: initTable[string,Value](), loaders: loaders)
+  Context(values: values, loaders: loaders)
 
 proc searchDirs*(c: Context, dirs: seq[string]) =
   c.loaders.add(Loader(kind: lkDir, searchDirs: dirs))
@@ -205,3 +205,8 @@ proc derive*(val: Value, c: Context): Context =
   if val.kind == vkTable:
     for k, val in val.vTable.pairs:
       result[k] = val
+
+proc toValues*(data: JsonNode): Table[string, Value] =
+  assert data.kind == JObject, "JsonNode must be a JObject"
+  for key, val in data.pairs:
+    result[key] = val.castValue

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -22,9 +22,7 @@ for spec_file in SPEC_FILES:
       for key, partial in spec["partials"].pairs:
         writeFile(fmt"./tests/{key}.mustache", partial.getStr)
     test(spec_file & " - " & name & " - " & desc):
-      let c = newContext(searchDirs = @["./tests"])
-      for key, val in data.pairs:
-        c[key] = val
+      let c = newContext(searchDirs = @["./tests"], values=data.toValues)
       check tpl.render(c) == expected
 
     if spec.hasKey("partials"):


### PR DESCRIPTION
* add a `values = initTable[string,Value]()` optional parameter to `newContext`
* add a `proc toValues*(data: JsonNode): Table[string, Value]` (exported)

this allows to initialize a context from a Json Object, see example in `test-spec.nim`:

```
let c = newContext(searchDirs = @["./tests"], values=data.toValues)
```

current behaviour (when no values parameter is provided) is not affected.