### PR TITLE
Fix bug that prevented custom values with a nested sequence of custom values

### DIFF
--- a/src/mustachepkg/values.nim
+++ b/src/mustachepkg/values.nim
@@ -116,7 +116,7 @@ proc castValue*[T](value: Table[string, T]): Value =
   Value(kind: vkTable, vTable: newValue)
 
 proc castValue*[T](value: seq[T]): Value =
-  Value(kind: vkSeq, vSeq: value.map(castValue))
+  Value(kind: vkSeq, vSeq: value.mapIt(it.castValue))
 
 proc castValue*(value: Value): Value = value
 

--- a/tests/test_values.nim
+++ b/tests/test_values.nim
@@ -58,3 +58,30 @@ test "set basic values to context":
 
   check not ctx["nonExisting"].castBool
 
+type
+  Stock = tuple
+    name: string
+    price: int
+  
+  StockList = tuple
+    stocks: seq[Stock]
+
+proc castValue(value: Stock): Value =
+  let newValue = new(Table[string, Value])
+  result = Value(kind: vkTable, vTable: newValue)
+  for k, v in value.fieldPairs:
+    newValue[k] = v.castValue
+
+proc castValue(value: StockList): Value =
+  let newValue = new(Table[string, Value])
+  result = Value(kind: vkTable, vTable: newValue)
+  for k, v in value.fieldPairs:
+    newValue[k] = v.castValue
+
+test "custom values":
+  let ctx = newContext()
+  let stock: Stock = (name: "NIM", price: 1)
+  ctx["stock"] = stock.castValue
+
+  let stocks: StockList = (stocks: @[stock])
+  ctx["stocks"] = stocks.castValue


### PR DESCRIPTION
I added the included test case, watched it fail, then made the change from `.map` to `.mapIt` to get it to work. I think this might be a bug with Nim, but I'm not sure.

It was failing with:

```
/Users/matt/lib/nim-mustache/src/mustachepkg/values.nim(119, 33) Error: type mismatch: got <seq[Stock], proc (value: int32): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: int8): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: int): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: int64): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: int16): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: float32): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: float64): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: string): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: bool): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: proc (s: string, c: Context): string{.closure.}): Value{.noSideEffect, gcsafe, locks: 0.} | proc (value: Table[system.string, castValue.T]): Value | proc (value: seq[T]): Value>
but expected one of:
proc map[T, S](s: openArray[T]; op: proc (x: T): S {.closure.}): seq[S]
  first type mismatch at position: 2
  required type for op: proc (x: T): S{.closure.}
  but expression 'castValue' is of type: None

expression: map(value, castValue)
```